### PR TITLE
Add rule option {decamelize: Boolean} to disable decamelized_filenames

### DIFF
--- a/lib/rules/filename-matches-component.js
+++ b/lib/rules/filename-matches-component.js
@@ -56,7 +56,11 @@ module.exports = {
     },
     schema: [{
       type: 'object',
-      properties: { },
+      properties: {
+        decamelize: {
+          type: 'boolean'
+        }
+      },
       additionalProperties: false
     }]
   },
@@ -84,6 +88,7 @@ module.exports = {
         var extension = path.extname(filename);
         var isFromStdin = ignoredFilenames.indexOf(filename) !== -1;
         var filenameWithoutExtension = path.basename(filename, extension);
+        var configuration = Object.assign({}, {decamelize: true}, context.options[0] || {});
 
         if (isFromStdin) {
           return;
@@ -94,9 +99,10 @@ module.exports = {
           if (list.hasOwnProperty(component)) {
             var node = list[component].node;
             var name = getComponentName(node);
-            if (name !== null && decamelize(name) !== filenameWithoutExtension) {
+            var expected = configuration.decamelize ? decamelize(name) : name;
+            if (name !== null && expected !== filenameWithoutExtension) {
               reportNonMatchingComponentName(
-                node, name, decamelize(name), filenameWithoutExtension);
+                node, name, expected, filenameWithoutExtension);
             }
           }
         }


### PR DESCRIPTION
This plugin was 95% what I was looking for, except that I don't have an expectation that filenames would be snake_case.

So I added a simple rule option to disable that functionality:

--------------

- `decamelize`: Boolean, *defaults to true*. 
  - If **true**, a component named `MyComponent` matches the filename `my_component`. 
  - If **false**, the file should also be named `MyComponent`. 

---------------

Should be backwards compatible.

No tests written yet, and didn't see docs for this rule (link in readme is broken) otherwise would have added this.

Wasn't sure about style, naming, etc, tried to keep it close to the original but feel free to suggest edits 😄 